### PR TITLE
Added a specific vundle description

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,6 @@ Plug 'dylanaraps/wal.vim'
 
 colorscheme wal
 ```
+
+Note, if using [Vundle](https://github.com/VundleVim/Vundle.vim), `colorscheme wal` declaration must come after `call vundle#end()`. This may similarly apply to other plugin managers.
+


### PR DESCRIPTION
Added specific vundle instruction circumvent potential headaches for vundle users with vim being unable to find colorscheme. Same issue may apply to other plugin managers.