### PR TITLE
Set better values for pair highlighting

### DIFF
--- a/colors/wal.vim
+++ b/colors/wal.vim
@@ -61,7 +61,7 @@ hi DiffText ctermbg=NONE ctermfg=4
 hi IncSearch ctermbg=3 ctermfg=0
 hi Search ctermbg=3 ctermfg=0
 hi Directory ctermbg=NONE ctermfg=4
-hi MatchParen ctermbg=8 ctermfg=0
+hi MatchParen ctermbg=1 ctermfg=8
 hi ColorColumn ctermbg=4 ctermfg=0
 hi signColumn ctermbg=NONE ctermfg=4
 hi ErrorMsg ctermbg=NONE ctermfg=8


### PR DESCRIPTION
I modified the colors of the MatchParen rule to be more visible. This fixes issue #4.

Demo:
![left of paren](https://user-images.githubusercontent.com/30285553/44000813-910baf96-9df4-11e8-8b8d-cc279c3c2e41.png)
![paren highlighted](https://user-images.githubusercontent.com/30285553/44000816-9849a998-9df4-11e8-9117-3cf9dc7cb72d.png)