### PR TITLE
Make split dividers more subtle

### DIFF
--- a/colors/wal.vim
+++ b/colors/wal.vim
@@ -32,12 +32,12 @@ hi Todo ctermbg=2 ctermfg=0
 hi Type ctermbg=NONE ctermfg=3
 hi Underlined ctermbg=NONE ctermfg=1 cterm=underline
 hi StatusLine ctermbg=7 ctermfg=0
-hi StatusLineNC ctermbg=NONE ctermfg=NONE
+hi StatusLineNC ctermbg=8 ctermfg=0
 hi TabLine ctermbg=NONE ctermfg=8
 hi TabLineFill ctermbg=NONE ctermfg=8
 hi TabLineSel ctermbg=4 ctermfg=0
 hi TermCursorNC ctermbg=3 ctermfg=0
-hi VertSplit ctermbg=NONE ctermfg=NONE
+hi VertSplit ctermbg=8 ctermfg=0
 hi Title ctermbg=NONE ctermfg=4
 hi CursorLine ctermbg=8 ctermfg=0
 hi LineNr ctermbg=NONE ctermfg=8


### PR DESCRIPTION
I changed the colours of the split dividers to make them stand out less and just get out of the way.

Before:
![image](https://user-images.githubusercontent.com/8503756/50303075-620f8080-0462-11e9-9ee7-8c12dc7b004a.png)

After:
![image](https://user-images.githubusercontent.com/8503756/50303084-6d62ac00-0462-11e9-9047-d01c2daf9887.png)
