### PR TITLE
Set background color for `Normal` group

### DIFF
--- a/colors/wal.vim
+++ b/colors/wal.vim
@@ -16,7 +16,7 @@ let g:colors_name = 'wal'
 " highlight groups {{{
 
 " set t_Co=16
-hi Normal ctermbg=NONE ctermfg=7
+hi Normal ctermbg=0 ctermfg=7
 hi NonText ctermbg=NONE ctermfg=0
 hi Comment ctermbg=NONE ctermfg=8
 hi Conceal ctermbg=NONE


### PR DESCRIPTION
Set `ctermbg` for the `Normal` highlight group to `0`. This is to fix [an issue](https://github.com/vim-airline/vim-airline/issues/2056) where some things were highlighting incorrectly when using [vim-airline](https://github.com/vim-airline/vim-airline/).