### PR TITLE
Make inactive splits more noticeable

### DIFF
--- a/colors/wal.vim
+++ b/colors/wal.vim
@@ -32,8 +32,8 @@ hi Number ctermbg=NONE ctermfg=3
 hi Todo ctermbg=2 ctermfg=0
 hi Type ctermbg=NONE ctermfg=3
 hi Underlined ctermbg=NONE ctermfg=1 cterm=underline
-hi StatusLine ctermbg=7 ctermfg=0
-hi StatusLineNC ctermbg=8 ctermfg=0
+hi StatusLine ctermbg=7 ctermfg=2
+hi StatusLineNC ctermbg=8 ctermfg=7
 hi TabLine ctermbg=NONE ctermfg=8
 hi TabLineFill ctermbg=NONE ctermfg=8
 hi TabLineSel ctermbg=4 ctermfg=0

--- a/colors/wal.vim
+++ b/colors/wal.vim
@@ -33,7 +33,7 @@ hi Todo ctermbg=2 ctermfg=0
 hi Type ctermbg=NONE ctermfg=3
 hi Underlined ctermbg=NONE ctermfg=1 cterm=underline
 hi StatusLine ctermbg=7 ctermfg=2
-hi StatusLineNC ctermbg=8 ctermfg=7
+hi StatusLineNC ctermbg=0 ctermfg=8
 hi TabLine ctermbg=NONE ctermfg=8
 hi TabLineFill ctermbg=NONE ctermfg=8
 hi TabLineSel ctermbg=4 ctermfg=0


### PR DESCRIPTION
Essentially a fix for #19 .

Here's an example of the change:
![Screenshot](https://user-images.githubusercontent.com/24630595/79082475-446bc780-7cf4-11ea-8f00-5ded943715f8.png)

Note that with plugins like vim-airline, this seems to not make that much of a difference.
