### PR TITLE
Add support for neovim-treesitter

### DIFF
--- a/colors/wal.vim
+++ b/colors/wal.vim
@@ -189,6 +189,15 @@ hi ALEWarning ctermbg=NONE ctermfg=3
 
 " }}}
 
+" Neovim treesitter {{{
+
+hi TSInclude ctermbg=NONE ctermfg=5
+hi TSNamespace ctermbg=NONE ctermfg=4
+hi TSRepeat ctermbg=NONE ctermfg=5
+hi TSOperator ctermbg=NONE ctermfg=4
+
+" }}}
+
 " Plugin options {{{
 
 let g:limelight_conceal_ctermfg = 8


### PR DESCRIPTION
Fixes #33.

This could possibly be a tad biased of course, but it looks way better now.

Before:
![2021-02-23-1614091271_screenshot_480x218](https://user-images.githubusercontent.com/4429327/108859763-d79cab80-75ed-11eb-8beb-c44b8c09441d.png)

After:
![2021-02-23-1614091484_screenshot_473x216](https://user-images.githubusercontent.com/4429327/108859984-13377580-75ee-11eb-9202-b298c5fee055.png)


Without treesitter:
![2021-02-23-1614091320_screenshot_482x211](https://user-images.githubusercontent.com/4429327/108859858-eedb9900-75ed-11eb-8a26-be0be785da33.png)

